### PR TITLE
Update v0.70.14

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,16 +19,21 @@ requirements:
   host:
     - pip
     - python
-    - setuptools >=0.6
-    - dill >=0.2.5
+    - setuptools
+    - wheel
+    - dill
   run:
     - python
-    - dill >=0.2.5
+    - dill >=0.3.6
 
 test:
   imports:
     - multiprocess
     - multiprocess.dummy
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://pypi.org/project/multiprocess/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,11 +11,10 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
-  build:
-    - {{ compiler('c') }}
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,11 +36,12 @@ test:
     - pip
 
 about:
-  home: https://pypi.org/project/multiprocess/
-  license: BSD-3-Clause
-  license_file: COPYING.txt
+  home: https://github.com/uqfoundation/multiprocess
   summary: better multiprocessing and multithreading in python
-
+  license: BSD-3-Clause
+  license_file:
+    - COPYING
+    - LICENSE
 extra:
   recipe-maintainers:
     - jschueller

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,13 @@
 {% set name = "multiprocess" %}
-{% set version = "0.70.12.2" %}
+{% set version = "0.70.14" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
-  sha256: 206bb9b97b73f87fec1ed15a19f8762950256aa84225450abc7150d02855a083
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 3eddafc12f2260d27ae03fe6069b12570ab4764ab59a75e81624fac453fbf46a
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,10 +37,17 @@ test:
 about:
   home: https://github.com/uqfoundation/multiprocess
   summary: better multiprocessing and multithreading in python
+  description: |
+    `multiprocess` is a fork of `multiprocessing`. `multiprocess` extends `multiprocessing` to provide enhanced serialization, using `dill`. `multiprocess` leverages `multiprocessing` to support the spawning of processes using the API of the python standard library's `threading module. multiprocessing has been distributed as part of the standard library since python 2.6.
   license: BSD-3-Clause
+  license_family: BSD
   license_file:
     - COPYING
     - LICENSE
+  license_url: https://github.com/uqfoundation/multiprocess/blob/multiprocess-{{ version }}/LICENSE
+  doc_url: https://multiprocess.readthedocs.io/en/latest/
+  doc_source_url: https://github.com/uqfoundation/multiprocess/tree/master/docs
+  dev_url: https://github.com/uqfoundation/multiprocess
 extra:
   recipe-maintainers:
     - jschueller


### PR DESCRIPTION
# Update multiprocess v0.70.14
Upstream: https://github.com/uqfoundation/multiprocess
Jira: https://anaconda.atlassian.net/browse/PKG-682

- Update version/SHA
- Update dependencies from upstream
- Remove unnecessary logic and compiler